### PR TITLE
Add info messages to search UI

### DIFF
--- a/css/search-results.css
+++ b/css/search-results.css
@@ -1,5 +1,11 @@
 /* Styles for the search-results component. */
 
+.search-results__info-message {
+  text-align: center;
+  font-style: italic;
+  color: #666;
+}
+
 .search-result-item {
   display: flex;
   padding: 0.5em;

--- a/index.html
+++ b/index.html
@@ -51,46 +51,62 @@
           </div>
         </div>
       </header>
-      <search-results :value="filteredSearchResults" />
+      <search-results
+        :value="filteredSearchResults"
+        :search-text="searchText"
+        :is-search-text-too-short="isSearchTextTooShort"
+      />
     </div>
 
     <template id="template-search-results">
       <div class="search-results">
-        <div v-for="item in value" :key="item.id" class="search-result-item">
-          <div class="search-result-item__main">
-            <div class="search-result-item__title-box">
-              <div class="search-result-item__title">
-                {{ item.title }}
-              </div>
-              <div
-                class="search-result-item__tier"
-                :class="'search-result-item__tier--type-' + item.tier"
-              >
-                {{ item.tier }}
-              </div>
-            </div>
-            <div class="search-result-item__stats">
-              <div class="search-result-item__stats-entry">
-                Views: {{ item.views }}
-              </div>
-              <div class="search-result-item__stats-entry">
-                Created: {{ item.createdAtDate.toLocaleDateString({}, {
-                dateStyle: 'long' }) }}
-              </div>
-              <div class="search-result-item__stats-entry">
-                Upvotes: {{ item.upvotes }}
-              </div>
-            </div>
-          </div>
-          <div class="search-result-item__content-type-bar">
-            <div
-              v-for="contentType in item.contentTypes"
-              class="search-result-item__content-type-label"
-            >
-              {{ contentType }}
-            </div>
-          </div>
+        <div v-if="!searchText" class="search-results__info-message">
+          No search text entered
         </div>
+        <div
+          v-else-if="isSearchTextTooShort"
+          class="search-results__info-message"
+        >
+          The search text is too short--please enter more! (You entered
+          <code>"{{ searchText }}"</code>)
+        </div>
+        <template v-else>
+          <div v-for="item in value" :key="item.id" class="search-result-item">
+            <div class="search-result-item__main">
+              <div class="search-result-item__title-box">
+                <div class="search-result-item__title">
+                  {{ item.title }}
+                </div>
+                <div
+                  class="search-result-item__tier"
+                  :class="'search-result-item__tier--type-' + item.tier"
+                >
+                  {{ item.tier }}
+                </div>
+              </div>
+              <div class="search-result-item__stats">
+                <div class="search-result-item__stats-entry">
+                  Views: {{ item.views }}
+                </div>
+                <div class="search-result-item__stats-entry">
+                  Created: {{ item.createdAtDate.toLocaleDateString({}, {
+                  dateStyle: 'long' }) }}
+                </div>
+                <div class="search-result-item__stats-entry">
+                  Upvotes: {{ item.upvotes }}
+                </div>
+              </div>
+            </div>
+            <div class="search-result-item__content-type-bar">
+              <div
+                v-for="contentType in item.contentTypes"
+                class="search-result-item__content-type-label"
+              >
+                {{ contentType }}
+              </div>
+            </div>
+          </div>
+        </template>
       </div>
     </template>
 

--- a/index.html
+++ b/index.html
@@ -70,6 +70,12 @@
           The search text is too short--please enter more! (You entered
           <code>"{{ searchText }}"</code>)
         </div>
+        <div
+          v-else-if="value.length === 0"
+          class="search-results__info-message"
+        >
+          No match for <code>"{{ searchText }}"</code>
+        </div>
         <template v-else>
           <div v-for="item in value" :key="item.id" class="search-result-item">
             <div class="search-result-item__main">

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
           </div>
         </div>
       </header>
-      <search-results :value="searchResults" />
+      <search-results :value="filteredSearchResults" />
     </div>
 
     <template id="template-search-results">

--- a/js/app.js
+++ b/js/app.js
@@ -41,12 +41,19 @@ const vm = new Vue({
   },
   computed: {
     /**
+     * Returns true if the search text is too short to trigger a search.
+     * @returns {boolean}
+     */
+    isSearchTextTooShort() {
+      return !this.searchText || this.searchText.length < 2;
+    },
+    /**
      * Returns guides that match the current search text (`searchText`).
      * @returns {Guide[]}
      */
     searchedGuides() {
       // Show nothing if the search text is less than 2 characters long
-      if (!this.searchText || this.searchText.length < 2) return [];
+      if (this.isSearchTextTooShort) return [];
 
       return this.fuse
         .search(this.searchText)

--- a/js/app.js
+++ b/js/app.js
@@ -41,17 +41,25 @@ const vm = new Vue({
   },
   computed: {
     /**
-     * @returns {SearchResultItem[]}
+     * Returns guides that match the current search text (`searchText`).
+     * @returns {Guide[]}
      */
-    searchResults() {
+    searchedGuides() {
       // Show nothing if the search text is less than 2 characters long
       if (!this.searchText || this.searchText.length < 2) return [];
 
-      /** @type {Guide[]} */
-      const results = this.fuse
+      return this.fuse
         .search(this.searchText)
         .map((resultItem) => resultItem.item);
-      return results
+    },
+    /**
+     * Returns search results filtered by currently active tier filters.
+     * @returns {SearchResultItem[]}
+     */
+    filteredSearchResults() {
+      /** @type {Guide[]} */
+      const searchedGuides = this.searchedGuides;
+      return searchedGuides
         .filter((guide) => this.activeTierFilters.includes(guide.tier))
         .map((guide) => {
           // Drop the 'content' key from the searchResultItem

--- a/js/search-results.js
+++ b/js/search-results.js
@@ -7,5 +7,10 @@ Vue.component("search-results", {
   template: "#template-search-results",
   props: {
     value: Array,
+    searchText: String,
+    isSearchTextTooShort: {
+      type: Boolean,
+      default: true,
+    },
   },
 });


### PR DESCRIPTION
Fix some issues discussed in #1:

* Show a "No match for `"XYZ"`" message when the searched & filtered result is empty
* Show a "No search text entered" message when the user has entered nothing
* Show a "Search text is too short" message if the search text is not long enough

Also, cache searched & filtered data separately for (possible) performance improvements when the user changes filters w/o fixing the text.
(Since searching is more expensive than filtering, search first, then filter.)