### PR TITLE
Strengthen type checks and fix code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,8 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
   },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+  },
 }

--- a/js/app.js
+++ b/js/app.js
@@ -3,12 +3,13 @@
 /// <reference path="./index.d.ts" />
 /// <reference path="./data.js" />
 
-const vm = new Vue({
-  el: "#app",
-  data: {
-    currentGuide: guides[0],
-    currentPage: "search",
-    guides: guides,
+const App = Vue.extend({
+  data() {
+    return {
+      currentGuide: guides[0],
+      currentPage: "search",
+      guides: guides,
+    };
   },
   methods: {
     /**
@@ -29,4 +30,8 @@ const vm = new Vue({
       this.currentPage = "search";
     },
   },
+});
+
+const vm = new App({
+  el: "#app",
 });

--- a/js/app.js
+++ b/js/app.js
@@ -17,7 +17,9 @@ const App = Vue.extend({
      * @param {string} guideId
      */
     openPageGuide(guideId) {
-      const guideToView = this.guides.find((guide) => guide.id === guideId);
+      /** @type {Guide[]} */
+      const guides = this.guides;
+      const guideToView = guides.find((guide) => guide.id === guideId);
       if (!guideToView)
         throw new Error(`Cannot find guide with ID: '${guideId}'`);
       this.currentGuide = guideToView;

--- a/js/fuse.d.ts
+++ b/js/fuse.d.ts
@@ -1,0 +1,272 @@
+// Copied from https://github.com/krisk/Fuse/blob/master/src/index.d.ts
+
+// Commented because it caused type checking errors
+// export default Fuse;
+export as namespace Fuse;
+
+declare class Fuse<T, O extends Fuse.IFuseOptions<T>> {
+  constructor(list: ReadonlyArray<T>, options?: O, index?: FuseIndex<T>);
+  /**
+   * Search function for the Fuse instance.
+   *
+   * ```typescript
+   * const list: MyType[] = [myType1, myType2, etc...]
+   * const options: Fuse.IFuseOptions<MyType> = {
+   *  keys: ['key1', 'key2']
+   * }
+   *
+   * const myFuse = new Fuse(list, options)
+   * let result = myFuse.search('pattern')
+   * ```
+   *
+   * @param pattern The pattern to search
+   * @param options `Fuse.FuseSearchOptions`
+   * @returns An array of search results
+   */
+  search<R = T>(
+    pattern: string | Fuse.Expression,
+    options?: Fuse.FuseSearchOptions
+  ): Fuse.FuseResult<R>[];
+
+  setCollection(docs: ReadonlyArray<T>, index?: FuseIndex<T>): void;
+
+  /**
+   * Adds a doc to the end the list.
+   */
+  add(doc: T): void;
+
+  /**
+   * Removes the doc at the specified index
+   */
+  removeAt(idx: number): void;
+
+  getIndex(): FuseIndex<T>;
+
+  /**
+   * Return the current version
+   */
+  static version: string;
+
+  /**
+   * Use this method to pre-generate the index from the list, and pass it
+   * directly into the Fuse instance.
+   *
+   * _Note that Fuse will automatically index the table if one isn't provided
+   * during instantiation._
+   *
+   * ```typescript
+   * const list: MyType[] = [myType1, myType2, etc...]
+   *
+   * const index = Fuse.createIndex<MyType>(
+   *  keys: ['key1', 'key2']
+   *  list: list
+   * )
+   *
+   * const options: Fuse.IFuseOptions<MyType> = {
+   *  keys: ['key1', 'key2']
+   * }
+   *
+   * const myFuse = new Fuse(list, options, index)
+   * ```
+   * @param keys    The keys to index
+   * @param list    The list from which to create an index
+   * @param options?
+   * @returns An indexed list
+   */
+  static createIndex<U>(
+    keys: Fuse.FuseOptionKeyObject[] | string[],
+    list: ReadonlyArray<U>,
+    options?: Fuse.FuseIndexOptions<U>
+  ): FuseIndex<U>;
+
+  static parseIndex<U>(
+    index: any,
+    options?: Fuse.FuseIndexOptions<U>
+  ): FuseIndex<U>;
+}
+
+declare class FuseIndex<T> {
+  constructor(options?: Fuse.FuseIndexOptions<T>);
+  setCollection(docs: ReadonlyArray<T>): void;
+  setKeys(keys: ReadonlyArray<string>): void;
+  setRecords(records: Fuse.FuseIndexRecords): void;
+  create(): void;
+  add(doc: T): void;
+  toJSON(): {
+    keys: ReadonlyArray<string>;
+    collection: Fuse.FuseIndexRecords;
+  };
+}
+
+declare namespace Fuse {
+  type FuseGetFunction<T> = (
+    obj: T,
+    path: string
+  ) => ReadonlyArray<string> | string;
+
+  export type FuseIndexOptions<T> = {
+    getFn: FuseGetFunction<T>;
+  };
+
+  // {
+  //   title: { '$': "Old Man's War" },
+  //   'author.firstName': { '$': 'Codenar' }
+  // }
+  //
+  // OR
+  //
+  // {
+  //   tags: [
+  //     { $: 'nonfiction', idx: 0 },
+  //     { $: 'web development', idx: 1 },
+  //   ]
+  // }
+  export type FuseSortFunctionItem = {
+    [key: string]: { $: string } | { $: string; idx: number }[];
+  };
+
+  // {
+  //   score: 0.001,
+  //   key: 'author.firstName',
+  //   value: 'Codenar',
+  //   indices: [ [ 0, 3 ] ]
+  // }
+  export type FuseSortFunctionMatch = {
+    score: number;
+    key: string;
+    value: string;
+    indices: ReadonlyArray<number>[];
+  };
+
+  // {
+  //   score: 0,
+  //   key: 'tags',
+  //   value: 'nonfiction',
+  //   idx: 1,
+  //   indices: [ [ 0, 9 ] ]
+  // }
+  export type FuseSortFunctionMatchList = FuseSortFunctionMatch & {
+    idx: number;
+  };
+
+  export type FuseSortFunctionArg = {
+    idx: number;
+    item: FuseSortFunctionItem;
+    score: number;
+    matches?: (FuseSortFunctionMatch | FuseSortFunctionMatchList)[];
+  };
+
+  export type FuseSortFunction = (
+    a: FuseSortFunctionArg,
+    b: FuseSortFunctionArg
+  ) => number;
+
+  // title: {
+  //   '$': "Old Man's War",
+  //   'n': 0.5773502691896258
+  // }
+  type RecordEntryObject = {
+    v: string; // The text value
+    n: number; // The field-length norm
+  };
+
+  // 'author.tags.name': [{
+  //   'v': 'pizza lover',
+  //   'i': 2,
+  //   'n: 0.7071067811865475
+  // }
+  type RecordEntryArrayItem = ReadonlyArray<RecordEntryObject & { i: number }>;
+
+  // TODO: this makes it difficult to infer the type. Need to think more about this
+  type RecordEntry = {
+    [key: string]: RecordEntryObject | RecordEntryArrayItem;
+  };
+
+  // {
+  //   i: 0,
+  //   '$': {
+  //     '0': { v: "Old Man's War", n: 0.5773502691896258 },
+  //     '1': { v: 'Codenar', n: 1 },
+  //     '2': [
+  //       { v: 'pizza lover', i: 2, n: 0.7071067811865475 },
+  //       { v: 'helo wold', i: 1, n: 0.7071067811865475 },
+  //       { v: 'hello world', i: 0, n: 0.7071067811865475 }
+  //     ]
+  //   }
+  // }
+  type FuseIndexObjectRecord = {
+    i: number; // The index of the record in the source list
+    $: RecordEntry;
+  };
+
+  // {
+  //   keys: null,
+  //   list: [
+  //     { v: 'one', i: 0, n: 1 },
+  //     { v: 'two', i: 1, n: 1 },
+  //     { v: 'three', i: 2, n: 1 }
+  //   ]
+  // }
+  type FuseIndexStringRecord = {
+    i: number; // The index of the record in the source list
+    v: string; // The text value
+    n: number; // The field-length norm
+  };
+
+  type FuseIndexRecords =
+    | ReadonlyArray<FuseIndexObjectRecord>
+    | ReadonlyArray<FuseIndexStringRecord>;
+
+  // {
+  //   name: 'title',
+  //   weight: 0.7
+  // }
+  export type FuseOptionKeyObject = {
+    name: string;
+    weight: number;
+  };
+
+  export interface IFuseOptions<T> {
+    isCaseSensitive?: boolean;
+    distance?: number;
+    findAllMatches?: boolean;
+    getFn?: FuseGetFunction<T>;
+    includeMatches?: boolean;
+    includeScore?: boolean;
+    keys?: FuseOptionKeyObject[] | string[];
+    location?: number;
+    minMatchCharLength?: number;
+    shouldSort?: boolean;
+    sortFn?: FuseSortFunction;
+    threshold?: number;
+    useExtendedSearch?: boolean;
+  }
+
+  // Denotes the start/end indices of a match
+  //                 start    end
+  //                   ↓       ↓
+  type RangeTuple = [number, number];
+
+  export type FuseResultMatch = {
+    indices: ReadonlyArray<RangeTuple>;
+    key?: string;
+    refIndex?: number;
+    value?: string;
+  };
+
+  export type FuseSearchOptions = {
+    limit: number;
+  };
+
+  export type FuseResult<T> = {
+    item: T;
+    refIndex: number;
+    score?: number;
+    matches?: ReadonlyArray<FuseResultMatch>;
+  };
+
+  export type Expression =
+    | { [key: string]: string }
+    | { $and?: Expression[] }
+    | { $or?: Expression[] };
+}

--- a/js/page-search.js
+++ b/js/page-search.js
@@ -67,9 +67,9 @@ Vue.component("page-search", {
       // Show nothing if the search text is less than 2 characters long
       if (this.isSearchTextTooShort) return [];
 
-      return this.fuse
-        .search(this.searchText)
-        .map((resultItem) => resultItem.item);
+      /** @type {Fuse<Guide, Object>} */
+      const fuse = this.fuse;
+      return fuse.search(this.searchText).map((resultItem) => resultItem.item);
     },
     /**
      * Returns search results filtered by currently active tier filters.

--- a/js/page-search.js
+++ b/js/page-search.js
@@ -4,6 +4,7 @@
  */
 
 /// <reference path="./index.d.ts" />
+/// <reference path="./fuse.d.ts" />
 
 const tierFilterTypes = {
   iron: {
@@ -107,8 +108,10 @@ Vue.component("page-search", {
     },
   },
   mounted() {
+    /** @type {Guide[]} */
+    const guides = this.guides;
     // Initialize Fuse.js
-    this.fuse = new Fuse(this.guides, {
+    this.fuse = new Fuse(guides, {
       keys: [
         "title",
         "author",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "checkJs": true,
+    "strict": true,
     "target": "es2017",
   },
   "typeAcquisition": {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,4 +3,9 @@
     "checkJs": true,
     "target": "es2017",
   },
+  "typeAcquisition": {
+    "include": [
+      "vue-ls", // Indirectly acquire Vue.js types
+    ],
+  },
 }


### PR DESCRIPTION
- Enable stricter type checking
- Add missing type definitions
    - For Vue, I had to acquire types indirectly through `@types/vue-ls`.
    - For Fuse.js, I chose to copy its `index.d.ts` into my project.
- Use JSDoc `@type` directives to work around Vue's data field types that VS Code fails to pick up.

Also, enable format-on-save for TypeScript files using Prettier (again). This was previously enabled in de67db9af2abd723e1fd7e379d218ef741f66867, but was accidentally dropped by @huangyuan999 in 469b9c2fd1a5ac7a5ef5da1b064c57195b255129.